### PR TITLE
Add green icon indicators for correct replies in GameView

### DIFF
--- a/game/src/components/GameView.vue
+++ b/game/src/components/GameView.vue
@@ -45,7 +45,12 @@ async function guess() {
             :name="gameStore.resolveName(reply.author)"
             :sent="reply.author === playerRegistered"
             :text="[reply.answer]"
-          />
+          >
+            <template v-slot:avatar>
+              <q-icon v-if="reply.isTitleCorrect" name="label" color="green" />
+              <q-icon v-if="reply.isArtistCorrect" name="person" color="green" />
+            </template>
+          </q-chat-message>
         </q-scroll-area>
         <q-input
           ref="guessInput"


### PR DESCRIPTION
Related to #1

Implements green icon indicators for correct replies in the GameView component.

- Adds `q-icon` components within `q-chat-message` components to display a green "label" icon for title correctness and a green "person" icon for artist correctness, based on the reply's properties.
- Utilizes `v-if` directives to conditionally render the correct icon according to the reply's correctness status.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jeremyVignelles/blindtest-mobile/issues/1?shareId=9f26e123-e618-4a42-8b21-eb31a856fa6d).