### PR TITLE
Add green icon indicators for correct replies in GameView

### DIFF
--- a/game/src/components/CorrectGuessIndicator.vue
+++ b/game/src/components/CorrectGuessIndicator.vue
@@ -1,18 +1,20 @@
 <template>
-  <q-btn round flat>
+  <q-btn round flat @click="tooltipShown = !tooltipShown">
     <q-icon :name="icon" size="sm" />
-    <q-badge rounded floating color="green">
-      <q-icon name="check_circle" />
+    <q-badge rounded floating color="green" class="q-pa-none">
+      <q-icon name="check_circle" size="xs" />
     </q-badge>
-    <q-tooltip>{{ tooltipText }}</q-tooltip>
+    <q-tooltip v-model="tooltipShown">{{ tooltipText }}</q-tooltip>
   </q-btn>
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue'
+import { defineProps, ref } from 'vue'
 
-const props = defineProps({
+defineProps({
   icon: String,
   tooltipText: String
 })
+
+const tooltipShown = ref(false)
 </script>

--- a/game/src/components/CorrectGuessIndicator.vue
+++ b/game/src/components/CorrectGuessIndicator.vue
@@ -1,0 +1,18 @@
+<template>
+  <q-btn round flat>
+    <q-icon :name="icon" size="sm" />
+    <q-badge rounded floating color="green">
+      <q-icon name="check_circle" />
+    </q-badge>
+    <q-tooltip>{{ tooltipText }}</q-tooltip>
+  </q-btn>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue'
+
+const props = defineProps({
+  icon: String,
+  tooltipText: String
+})
+</script>

--- a/game/src/components/GameView.vue
+++ b/game/src/components/GameView.vue
@@ -49,16 +49,26 @@ async function guess() {
             <template v-slot:stamp>
               <q-btn v-if="reply.isTitleCorrect" round flat>
                 <q-icon name="label" size="sm" />
-                <q-badge v-if="reply.isTitleCorrect" floating color="green">
-                  <q-icon name="check_circle" />
-                </q-badge>
+                <q-badge
+                  v-if="reply.isTitleCorrect"
+                  floating
+                  rounded
+                  color="green"
+                  class="q-pa-none"
+                  ><q-icon name="check_circle" size="xs"
+                /></q-badge>
                 <q-tooltip>Le titre est correct</q-tooltip>
               </q-btn>
               <q-btn v-if="reply.isArtistCorrect" round flat>
                 <q-icon name="person" size="sm" />
-                <q-badge v-if="reply.isArtistCorrect" floating color="green">
-                  <q-icon name="check_circle" />
-                </q-badge>
+                <q-badge
+                  v-if="reply.isArtistCorrect"
+                  floating
+                  rounded
+                  color="green"
+                  class="q-pa-none"
+                  ><q-icon name="check_circle" size="xs"
+                /></q-badge>
                 <q-tooltip>L'artiste est correct</q-tooltip>
               </q-btn>
             </template>

--- a/game/src/components/GameView.vue
+++ b/game/src/components/GameView.vue
@@ -45,7 +45,12 @@ async function guess() {
             :name="gameStore.resolveName(reply.author)"
             :sent="reply.author === playerRegistered"
             :text="[reply.answer]"
-          />
+          >
+            <template v-slot:stamp>
+              <q-icon v-if="reply.isTitleCorrect" name="label" color="green" />
+              <q-icon v-if="reply.isArtistCorrect" name="person" color="green" />
+            </template>
+          </q-chat-message>
         </q-scroll-area>
         <q-input
           ref="guessInput"

--- a/game/src/components/GameView.vue
+++ b/game/src/components/GameView.vue
@@ -3,6 +3,7 @@ import { ref, inject } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useGameStore } from '@/stores/gameStore'
 import { socketSymbol } from '@/plugins/socket'
+import CorrectGuessIndicator from './CorrectGuessIndicator.vue'
 import type { QInput } from 'quasar'
 
 const socketService = inject(socketSymbol)!
@@ -47,30 +48,16 @@ async function guess() {
             :text="[reply.answer]"
           >
             <template v-slot:stamp>
-              <q-btn v-if="reply.isTitleCorrect" round flat>
-                <q-icon name="label" size="sm" />
-                <q-badge
-                  v-if="reply.isTitleCorrect"
-                  floating
-                  rounded
-                  color="green"
-                  class="q-pa-none"
-                  ><q-icon name="check_circle" size="xs"
-                /></q-badge>
-                <q-tooltip>Le titre est correct</q-tooltip>
-              </q-btn>
-              <q-btn v-if="reply.isArtistCorrect" round flat>
-                <q-icon name="person" size="sm" />
-                <q-badge
-                  v-if="reply.isArtistCorrect"
-                  floating
-                  rounded
-                  color="green"
-                  class="q-pa-none"
-                  ><q-icon name="check_circle" size="xs"
-                /></q-badge>
-                <q-tooltip>L'artiste est correct</q-tooltip>
-              </q-btn>
+              <correct-guess-indicator
+                v-if="reply.isTitleCorrect"
+                icon="label"
+                tooltip-text="Le titre est correct"
+              />
+              <correct-guess-indicator
+                v-if="reply.isArtistCorrect"
+                icon="person"
+                tooltip-text="L'artiste est correct"
+              />
             </template>
           </q-chat-message>
         </q-scroll-area>

--- a/game/src/components/GameView.vue
+++ b/game/src/components/GameView.vue
@@ -47,8 +47,20 @@ async function guess() {
             :text="[reply.answer]"
           >
             <template v-slot:stamp>
-              <q-icon v-if="reply.isTitleCorrect" name="label" color="green" />
-              <q-icon v-if="reply.isArtistCorrect" name="person" color="green" />
+              <q-btn v-if="reply.isTitleCorrect" round flat>
+                <q-icon name="label" size="sm" />
+                <q-badge v-if="reply.isTitleCorrect" floating color="green">
+                  <q-icon name="check_circle" />
+                </q-badge>
+                <q-tooltip>Le titre est correct</q-tooltip>
+              </q-btn>
+              <q-btn v-if="reply.isArtistCorrect" round flat>
+                <q-icon name="person" size="sm" />
+                <q-badge v-if="reply.isArtistCorrect" floating color="green">
+                  <q-icon name="check_circle" />
+                </q-badge>
+                <q-tooltip>L'artiste est correct</q-tooltip>
+              </q-btn>
             </template>
           </q-chat-message>
         </q-scroll-area>


### PR DESCRIPTION
Related to #1

Implements visual feedback for correct replies in the GameView component of the blindtest-mobile game.

- Adds `q-icon` components within the `q-chat-message` component to display green icons indicating correct replies.
  - Utilizes `v-if` directives to conditionally render a 'label' icon for title correctness and a 'person' icon for artist correctness.
  - Ensures icons are placed in the stamp slot to visually indicate correctness adjacent to the chat messages.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jeremyVignelles/blindtest-mobile/issues/1?shareId=47b51b81-ec1c-4be6-ac12-5424e9fe1215).